### PR TITLE
Check unicode links correctly

### DIFF
--- a/checkPages.js
+++ b/checkPages.js
@@ -55,6 +55,36 @@ module.exports = function(host, options, done) {
     });
   }
 
+  /* Converts http://examplé.com/rosé?rosé=1 to
+   * http://examplé.com/ros%C3%A9?ros%C3%A9=1 so that servers which expect
+   * ASCII only requests can handle it */
+  function fixNonAsciiLink(link) {
+    var parsed = url.parse(link);
+    if (/^[\u0000-\u007f]*$/.test(parsed.path)) {
+      return link;
+    }
+    /* We need to decodeURI and then encodeURI, so that all non-ASCII
+      * characters get escaped, not just whitespace like %20 */
+    var pathname = parsed.pathname;
+    var query = parsed.query;
+    try {
+      pathname = decodeURI(pathname);
+    } catch (e) { /* do nothing */ }
+    try {
+      query = decodeURI(query);
+    } catch (e) { /* do nothing */ }
+    var rv = url.format({
+      protocol: parsed.protocol,
+      slashes: parsed.slashes,
+      host: parsed.host,
+      auth: parsed.auth,
+      pathname: encodeURI(pathname),
+      query: encodeURI(query),
+      hash: parsed.hash
+    });
+    return rv;
+  }
+
   // Returns a callback to test the specified link
   function testLink(page, link, retryWithGet) {
     return function(callback) {
@@ -94,7 +124,7 @@ module.exports = function(host, options, done) {
       }
       var res;
       var useGetRequest = retryWithGet || options.queryHashes;
-      var req = requestFor(link)(link, {
+      var req = requestFor(link)(fixNonAsciiLink(link), {
         method: useGetRequest ? 'GET' : 'HEAD',
         followRedirect: !options.noRedirects
       })
@@ -172,7 +202,7 @@ module.exports = function(host, options, done) {
     return function(callback) {
       var logError = logPageError.bind(null, page);
       var start = Date.now();
-      requestFor(page).get(page, function(err, res, body) {
+      requestFor(page).get(fixNonAsciiLink(page), function(err, res, body) {
         var elapsed = Date.now() - start;
         if (err) {
           logError('Page error (' + err.message + '): ' + page + ' (' + elapsed + 'ms)');

--- a/test/checkPages_test.js
+++ b/test/checkPages_test.js
@@ -50,7 +50,7 @@ function runTest(options, callback) {
 function testOutput(test, log, error, exception) {
   return function(err, context, count) {
     if (err || exception) {
-      test.equal(err.message, exception, 'Wrong exception text');
+      test.equal(err && err.message, exception, 'Wrong exception text');
     }
     if (context) {
       test.equal(context.log.length, log.length, 'Wrong log count');

--- a/test/checkPages_test.js
+++ b/test/checkPages_test.js
@@ -1462,5 +1462,27 @@ exports.checkPages = {
     testOutput(test,
       ['Page: file:test/validPage.html (00ms)'],
       []));
+  },
+
+  nonAscii: function(test) {
+    test.expect(7);
+    nock('http://example.com')
+      .head(encodeURI('/first/☺')).reply(200)
+      .get(encodeURI('/first/☺')).reply(200)
+      .head(encodeURI('/second/☺')).reply(200)
+      .get(encodeURI('/second/☺')).reply(200)
+      .head(encodeURI('/third/☺ ☺')).reply(200)
+      .get(encodeURI('/third/☺ ☺')).reply(200);
+    runTest({
+      pageUrls: ['test/nonAscii.html'],
+      checkLinks: true
+    },
+    testOutput(test,
+      ['Page: file:test/nonAscii.html (00ms)',
+       'Link: http://example.com/first/☺ (00ms)',
+       'Link: http://example.com/second/%E2%98%BA (00ms)',
+       'Link: http://example.com/third/☺%20☺ (00ms)'],
+      []
+    ));
   }
 };

--- a/test/nonAscii.html
+++ b/test/nonAscii.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset=UTF-8>
+  <title>Valid Page</title>
+</head>
+<body>
+    <a href="http://example.com/first/☺">First</a>
+    <a href="http://example.com/second/%E2%98%BA">Second</a>
+    <a href="http://example.com/third/☺ ☺">Third</a>
+</body>
+</html>


### PR DESCRIPTION
Take a web page, which is correctly encoded in UTF-8 and has set the UTF-8 header correctly, that has a link like this:

```
<a href="https://fr.wikipedia.org/wiki/Café_(établissement)">café</a>
```

If you click on the link, the browser encodes/escapes the URL to this:

```
https://fr.wikipedia.org/wiki/Caf%C3%A9_%28%C3%A9tablissement%29
```

And sends a GET request with that URL. If the browser forgets to do encode/escape it, some servers won't accept the request (although it seems some servers do recover well).

The patch included fixes check-pages to handle this use-case correctly, even when the URL contains white-space, and it includes a test.
